### PR TITLE
chore: add permissions for github token to readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.idea/
+.vscode/
+
 # Dependency directory
 node_modules
 
@@ -105,3 +108,5 @@ lib/**/*
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+venv

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ it does follow the syntax of `type(scope)!: message` where `(scope)` and `!` are
 
 ## Inputs
 
-| key                  | description                                               | default              | required |
-|----------------------|-----------------------------------------------------------|----------------------|----------|
-| `configuration-path` | Path to the configuration file                            | `.github/pr-labeler` | `false`  |
-| `token`              | Github access token with permission to add labels to a PR |                      | `true`   |
+| key                  | description                                                                                                         | default              | required |
+|----------------------|---------------------------------------------------------------------------------------------------------------------|----------------------|----------|
+| `configuration-path` | Path to the configuration file                                                                                      | `.github/pr-labeler` | `false`  |
+| `token`              | Github access token with `contents: read`, `issues: read`, `pull-requests: write` permissions to add labels to a PR |                      | `true`   |
 
 ## Configuration
 
@@ -65,12 +65,21 @@ on:
 
 jobs:
   label-pr:
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: grafana/pr-labeler-action@v0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+> [!IMPORTANT]
+> Permissions are specified within the job definition. This prevents permitting more than is needed in other jobs.
+> 
+> If you prefer not using the generated `secrets.GITHUB_TOKEN` you can use a PAT or Github App (recommended) token with the correct permissions and omit the permissions block
 
 The above example workflow will do the following
 


### PR DESCRIPTION
- #49 

- Add permissions for `secrets.GITHUB_TOKEN` to be able to add labels to a PR